### PR TITLE
Enhanced DeepLinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This repository contains the [Kochava](https://www.kochava.com) integration for 
     >      //implementation 'com.google.android.gms:play-services-base:12.0.1'
     >
     >      //Required: Install Referrer (If publishing to the Google Play Store)
-    >      implementation 'com.android.installreferrer:installreferrer:1.0'
+    >      implementation 'com.android.installreferrer:installreferrer:1+'
     >
     >      //Optional: Location Collection. Note: This feature must also be enabled server side before collection will occur.
     >      implementation 'com.google.android.gms:play-services-location:15.0.1'
@@ -63,6 +63,51 @@ identityLink.put("key2", "identity2");
 KochavaKit.setIdentityLink(identityLink);
 ```
 
+### Attribution, Deeplinking and Enhanced Deeplinking results
+
+Kochava offers a number of APIs to process attribution and deeplinking data. In our abstraction, the 
+results from these are all routed to our `AttributionListener` under distinct, constant keys.
+
+```kotlin
+val attributionListener = object: AttributionListener {
+    override fun onResult(result: AttributionResult) {
+        when (result.serviceProviderId) {
+            MParticle.ServiceProviders.KOCHAVA -> {
+                val parameters = result.parameters ?: JSONObject()
+
+                //process Attribution results
+                if (parameters.has(KochavaKit.ATTRIBUTION_PARAMETERS)) {
+                    val attributionParamters =
+                        parameters.getJSONObject(KochavaKit.ATTRIBUTION_PARAMETERS)
+                }
+
+                //process Deeplink results
+                if (parameters.has(KochavaKit.DEEPLINK_PARAMETERS)) {
+                    val deeplinkParameters =
+                        parameters.getJSONObject(KochavaKit.DEEPLINK_PARAMETERS)
+                }
+
+                //process Enhanced Deeplink results
+                if (parameters.has(KochavaKit.ENHANCED_DEEPLINK_PARAMETERS)) {
+                    val enhancedDeeplinkParameters =
+                        parameters.getJSONObject(KochavaKit.ENHANCED_DEEPLINK_PARAMETERS)
+                }
+            }
+        }
+    }
+
+    override fun onError(error: AttributionError) {
+        //error handling
+    }
+}
+
+MParticle.start(
+    MParticleOptions.builder(this)
+        .attributionListener(attributionListener)
+        .build()
+)
+
+```
 
 ### License
 

--- a/src/main/java/com/mparticle/kits/KochavaKit.java
+++ b/src/main/java/com/mparticle/kits/KochavaKit.java
@@ -6,6 +6,8 @@ import android.location.Location;
 
 import com.kochava.base.AttributionUpdateListener;
 import com.kochava.base.DeepLinkListener;
+import com.kochava.base.Deeplink;
+import com.kochava.base.DeeplinkProcessedListener;
 import com.kochava.base.ReferralReceiver;
 import com.kochava.base.Tracker;
 import com.kochava.base.Tracker.Configuration;
@@ -26,6 +28,7 @@ import java.util.Map;
 public class KochavaKit extends KitIntegration implements KitIntegration.AttributeListener {
     public static final String ATTRIBUTION_PARAMETERS = "attribution";
     public static final String DEEPLINK_PARAMETERS = "deeplink";
+    public static final String ENHANCED_DEEPLINK_PARAMETERS = "enhancedDeeplink";
 
     private static final String APP_ID = "appId";
     private static final String USE_CUSTOMER_ID = "useCustomerId";
@@ -66,6 +69,7 @@ public class KochavaKit extends KitIntegration implements KitIntegration.Attribu
 
         if (attributionEnabled) {
             Tracker.setDeepLinkListener(getKitManager().getLaunchUri(), mDeepLinkListener);
+            Tracker.processDeeplink(getKitManager().getLaunchUri().toString(), mDeepLinkProcessedListener);
         }
         return null;
     }
@@ -183,6 +187,15 @@ public class KochavaKit extends KitIntegration implements KitIntegration.Attribu
         public void onDeepLink(Map<String, String> map) {
             if (!MPUtility.isEmpty(map)) {
                 setAttributionResultParameter(DEEPLINK_PARAMETERS, MPUtility.mapToJson(map));
+            }
+        }
+    };
+
+    private DeeplinkProcessedListener mDeepLinkProcessedListener = new DeeplinkProcessedListener() {
+        @Override
+        public void onDeeplinkProcessed(Deeplink deeplink) {
+            if (deeplink != null) {
+                setAttributionResultParameter(ENHANCED_DEEPLINK_PARAMETERS, deeplink.toJson());
             }
         }
     };


### PR DESCRIPTION
Add new Kochava API for "Enhanced Deeplinks".

It's pretty difficult to ascertain from the Kochava docs exactly how an "Enhanced Deeplink" differs from their regular deeplink and attribution callbacks in practice, so we are returning the payload received from the callback under a distinct key in our `AttributionListener` callback. I added an example to the README, so let me know if that is clear enough